### PR TITLE
Improve display of class name and wrapping of test results 

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -49,7 +49,7 @@ class Printer extends _ResultPrinter
     /**
      * @var int
      */
-    private $maxClassNameLength = 35;
+    private $maxClassNameLength = 50;
 
     /**
      * @var int
@@ -94,8 +94,8 @@ class Printer extends _ResultPrinter
         $this->colors             = new Colors;
         $this->configuration      = new Config($this->configFileName);
 
-        $this->maxClassNameLength = intval($this->maxNumberOfColumns * 0.5);
         $this->maxNumberOfColumns = $this->getWidth();
+        $this->maxClassNameLength = min((int) ($this->maxNumberOfColumns / 2), $this->maxClassNameLength);
 
         // setup module options
         $this->printerOptions     = $this->configuration->all();
@@ -279,7 +279,7 @@ class Printer extends _ResultPrinter
         return (dirname(dirname(__FILE__)));
     }
 
-        /**
+    /**
      * Gets the terminal width.
      *
      * @return int


### PR DESCRIPTION
This PR fixes two display issues:

### Truncated class names

Class names get aggressively truncated unless the terminal window is quite wide. For example, when the window is 120 columns wide, the output looks like this:

<img width="970" alt="screen shot 2017-12-22 at 12 03 01 am" src="https://user-images.githubusercontent.com/357312/34286099-7dd2fb1e-e6ac-11e7-9eea-f18798c3f51a.png">

Instead, this PR respects the `maxClassNameLength` setting (which I've adjusted to 50 characters):

<img width="967" alt="screen shot 2017-12-22 at 12 04 01 am" src="https://user-images.githubusercontent.com/357312/34286167-f7a0da24-e6ac-11e7-8052-856624cd3770.png">

When the window is too narrow for that many characters, it splits the class name / results display into two columns of equal widths. The result looks like this:

<img width="683" alt="screen shot 2017-12-22 at 12 14 24 am" src="https://user-images.githubusercontent.com/357312/34286213-27ca2a70-e6ad-11e7-952e-199e8891fa36.png">

### Wrapping of test results

If test results extend beyond the edge of the window, they don't wrap/indent properly. Current behavior:

<img width="401" alt="screen shot 2017-12-22 at 12 06 01 am" src="https://user-images.githubusercontent.com/357312/34286243-65af4c9e-e6ad-11e7-8124-4d379eef10e9.png">

This fixes the display so 2nd and subsequent lines of results for a single test will properly wrap and align with the start of the previous line:

<img width="403" alt="screen shot 2017-12-22 at 12 06 31 am" src="https://user-images.githubusercontent.com/357312/34286271-889ba036-e6ad-11e7-9207-d47a0f9aa3c4.png">
