### PR TITLE
Print class name in Printer::writeProgressWithColor()

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -137,6 +137,10 @@ class Printer extends _ResultPrinter
      */
     protected function writeProgressWithColor($color, $buffer)
     {
+        if (! $this->debug) {
+            $this->printClassName();
+        }
+
         $this->printTestCaseStatus($color, $buffer);
     }
 


### PR DESCRIPTION
Fixes #8.

I'm not exactly sure why, but when a test fails, `Printer::writeProgressWithColor()` is called instead of `Printer::writeProgress()`. Because this function didn't call `Printer::printClassName()` it caused the issue described in #8.