### PR TITLE
Use stty for terminal width detection

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -290,6 +290,7 @@ class Printer extends _ResultPrinter
      */
     private function getWidth()
     {
-        return (int) exec('tput cols');
+        // 'stty size' output example: 36 120
+        return (int) explode(' ', exec('stty size'))[1];
     }
 }


### PR DESCRIPTION
`tput` is not available in some systems, like Alpine that is widely used in CI tasks. `stty` is more widely available and is part of coreutils.