### PR TITLE
Add support for PHPUnit 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codedungeon/phpunit-result-printer",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "PHPUnit Pretty Result Printer",
   "keywords": ["phpunit", "printer", "result-printer", "composer", "package"],
   "license": "MIT",
@@ -10,7 +10,7 @@
   }],
   "type": "library",
   "require": {
-    "php": "^5.6|^7.0",
+    "php": "^7.1",
     "hassankhan/config": "^0.10.0",
     "symfony/yaml": "^2.7|^3.0|^4.0"
   },

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -17,11 +17,11 @@ if (class_exists('\PHPUnit_TextUI_ResultPrinter')) {
     }
 }
 
-// use this entrypoint for PHPUnit 6.x
+// use this entrypoint for PHPUnit 6.x and 7.x
 if (class_exists('\PHPUnit\TextUI\ResultPrinter')) {
     class _ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     {
-        public function startTest(\PHPUnit\Framework\Test $test)
+        public function startTest(\PHPUnit\Framework\Test $test): void
         {
             $this->className = get_class($test);
             parent::startTest($test);
@@ -118,7 +118,7 @@ class Printer extends _ResultPrinter
     /**
      * {@inheritdoc}
      */
-    protected function writeProgress($progress)
+    protected function writeProgress($progress): void
     {
         if (!$this->debug) {
             $this->printClassName();
@@ -130,7 +130,7 @@ class Printer extends _ResultPrinter
     /**
      * {@inheritdoc}
      */
-    protected function writeProgressWithColor($color, $buffer)
+    protected function writeProgressWithColor($color, $buffer): void
     {
         if (!$this->debug) {
             $this->printClassName();


### PR DESCRIPTION
[PHPUnit 7.0 was released on 02/02/2018](https://phpunit.de/announcements/phpunit-7.html).  The existing printer in this repository didn't work due to PHPUnit 7.0 supporting PHP >=7.1 and needed return types.  Because of that, this code breaks compatibility with PHP 5.X and 7.0.

I upgraded the version in `composer.json` from 0.5.4 to 0.6.0.  I ran the tests included in this repository and they all passed.  Also, I tested this code using PHPUnit 6.5 and PHPUnit 7.0.