### PR TITLE
Update TravisCI to build on PHP 7.1 and newer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: php
 dist: trusty
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - php: nightly
 
 branches:
   only:
@@ -17,3 +20,6 @@ install:
 
 script:
   - ./vendor/bin/phpunit
+
+notifications:
+  email: false

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,6 @@
 {
   "name": "codedungeon/phpunit-result-printer",
-<<<<<<< HEAD
   "version": "0.5.5",
-=======
-  "version": "0.6.0",
->>>>>>> 962dc405bdefa008d377e59441f182c329f50d50
   "description": "PHPUnit Pretty Result Printer",
   "keywords": ["phpunit", "printer", "result-printer", "composer", "package"],
   "license": "MIT",


### PR DESCRIPTION
Since merging of pull request #28, PHP prior to 7.1 is no longer supported.  This updates TravisCI to reflect that change and to build on modern versions of PHP and run tests.