### PR TITLE
Add support for PHPUnit v7.0.2

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -119,7 +119,7 @@ class Printer extends _ResultPrinter
     /**
      * {@inheritdoc}
      */
-    protected function writeProgress($progress)
+    protected function writeProgress($progress): void
     {
         if (!$this->debug) {
             $this->printClassName();
@@ -131,7 +131,7 @@ class Printer extends _ResultPrinter
     /**
      * {@inheritdoc}
      */
-    protected function writeProgressWithColor($color, $buffer)
+    protected function writeProgressWithColor($color, $buffer): void
     {
         if (!$this->debug) {
             $this->printClassName();


### PR DESCRIPTION
This commit resolve issue for PHPUnit v7.0.2 used in Laravel v5.6.12:

![image](https://user-images.githubusercontent.com/5069097/37857381-9b2ccd8c-2f0b-11e8-85f2-f074fdf987f5.png)

Commit has breaking changes! In PHPUnit with lower version error will be thrown