### PR TITLE
Drop PHP 5.6 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2


### PR DESCRIPTION
The package limits PHP to version ^7.0 but travis has a 5.6 case