### PR TITLE
some code require php version >= 7.1 (check issue #53)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 dist: trusty
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   }],
   "type": "library",
   "require": {
-    "php": "^7.0",
+    "php": "^7.1",
     "hassankhan/config": "^0.10.0",
     "symfony/yaml": "^2.7|^3.0|^4.0"
   },


### PR DESCRIPTION
certain features specific for that version are used in some places. For example, void return type is used here: https://github.com/mikeerickson/phpunit-pretty-result-printer/blob/master/src/Printer.php#L160.

Please check #53 