### PR TITLE
Fixed typo in property name

### DIFF
--- a/src/PrinterTrait.php
+++ b/src/PrinterTrait.php
@@ -332,7 +332,7 @@ trait PrinterTrait
                 break;
             case 'E':
                 $color = 'fg-red,bold';
-                $buffer = $this->simpleOutput ? 'E' : $this->makers['error']; // '⚈';
+                $buffer = $this->simpleOutput ? 'E' : $this->markers['error']; // '⚈';
                 $buffer .= !$this->debug ? '' : ' Error';
                 break;
         }


### PR DESCRIPTION
A test with errors was causing the printer to throw its own error due to a typo.