### PR TITLE
Autoload ResultPrinter classes, since they're named differently now

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -6,17 +6,15 @@ use PHPUnit\Runner\Version;
 use PHPUnit_TextUI_ResultPrinter;
 
 if (class_exists(PHPUnit_TextUI_ResultPrinter::class)) {
-    require __DIR__ . '/ResultPrinter5.php';
-
     class Printer extends ResultPrinter5
     {
         use PrinterTrait;
     }
 }
 
-if (version_compare(Version::series(), '6.99.99', '<=')) {
-    require __DIR__ . '/ResultPrinter6.php';
+$high = version_compare(Version::series(), '6.99.99', '<=');
 
+if ($high) {
     class Printer extends ResultPrinter6
     {
         use PrinterTrait;
@@ -27,8 +25,6 @@ $low = version_compare(Version::series(), '7.0', '>=');
 $high = version_compare(Version::series(), '7.0.99', '<=');
 
 if ($low && $high) {
-    require __DIR__ . '/ResultPrinter70.php';
-
     class Printer extends ResultPrinter70
     {
         use PrinterTrait;
@@ -39,8 +35,6 @@ $low = version_compare(Version::series(), '7.1', '>=');
 $high = true; // version_compare(Version::series(),'7.1.99','<=');
 
 if ($low && $high) {
-    require __DIR__ . '/ResultPrinter71.php';
-
     class Printer extends ResultPrinter71
     {
         use PrinterTrait;


### PR DESCRIPTION
I think they were included, before, because they all had the same name. Now that they're named differently, we should be able to autoload them. 