### PR TITLE
Wrap to newline at the expected output sequence

### DIFF
--- a/src/PrinterTrait.php
+++ b/src/PrinterTrait.php
@@ -426,6 +426,6 @@ trait PrinterTrait
         if ($this->debug) {
             $this->writeNewLine();
         }
-        $this->column += 2;
+        $this->column += 3;
     }
 }


### PR DESCRIPTION
The checkmarks are technically two columns, and then there is a space after them, thus we need to move the cursor 3 places, and not two.

This fixes https://github.com/mikeerickson/phpunit-pretty-result-printer/issues/104