### PR TITLE
Bump minimum requirement of codedungeon/php-cli-colors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - COMPOSER_OPTS="--no-interaction --prefer-dist --no-suggest --prefer-lowest"
 
 install:
-  - travis_retry composer install $COMPOSER_OPTS
+  - travis_retry composer update $COMPOSER_OPTS
 
 script:
   - ./vendor/bin/phpunit -c phpunit.ci.xml  --coverage-clover=coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,12 @@ branches:
   only:
     - master
 
+env:
+  - COMPOSER_OPTS="--no-interaction --prefer-dist --no-suggest"
+  - COMPOSER_OPTS="--no-interaction --prefer-dist --no-suggest --prefer-lowest"
+
 install:
-  - travis_retry composer install --no-interaction --prefer-dist --no-suggest
+  - travis_retry composer install $COMPOSER_OPTS
 
 script:
   - ./vendor/bin/phpunit -c phpunit.ci.xml  --coverage-clover=coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": "^7.1",
     "hassankhan/config": "^1.0",
     "symfony/yaml": "^2.7|^3.0|^4.0",
-    "codedungeon/php-cli-colors": "^1.10"
+    "codedungeon/php-cli-colors": "^1.10.2"
   },
   "require-dev": {
     "spatie/phpunit-watcher": "^1.5",


### PR DESCRIPTION
This PR bumps the minimum requirement of `codedungeon/php-cli-colors` to `^1.10.2` in order to prevent this package (and _any_ package/project that depends on it) from crashing while running PHPUnit with lowest dependencies (`--prefer-lowest`).

```
Fatal error: Uncaught Error: Class 'Codedungeon\PHPCliColors\Color' not found in src/PrinterTrait.php on line 86
```

This PR also changes the Travis CI configuration so it tests the package against its highest _and_ lowest dependencies to prevent similar errors from occuring in the future.
