### PR TITLE
Fix potential fatal error from sprintf not getting enough arguments when formatting exception message

### DIFF
--- a/src/ResultPrinter71.php
+++ b/src/ResultPrinter71.php
@@ -59,22 +59,29 @@ if ($low && $high) {
 
         protected function formatExceptionMsg($exceptionMessage): string
         {
+            $exceptionMessage = preg_replace('/%/u', '%%', $exceptionMessage);
+
             $exceptionMessage = str_replace("+++ Actual\n", '', $exceptionMessage);
             $exceptionMessage = str_replace("--- Expected\n", '', $exceptionMessage);
             $exceptionMessage = str_replace('@@ @@', '', $exceptionMessage);
 
-            $marker = $this->markers['fail'];
-            if ($this->colors) {
-                $exceptionMessage = preg_replace('/^(Exception.*)$/m', "\033[01;31m$1\033[0m", $exceptionMessage);
-                $exceptionMessage = preg_replace('/(Failed.*)$/m', "\033[01;31m %s$1\033[0m", $exceptionMessage);
-                $exceptionMessage = preg_replace("/(\-+.*)$/m", "\033[01;32m$1\033[0m", $exceptionMessage);
-                $exceptionMessage = preg_replace("/(\++.*)$/m", "\033[01;31m$1\033[0m", $exceptionMessage);
-            }
             if (strpos($exceptionMessage, 'This test did not perform any assertions') !== false) {
                 $exceptionMessage = $this->setMessageColor('risky', 'This test did not perform any assertions.');
+            } else {
+
+                $marker = $this->markers['fail'];
+
+                if ($this->colors) {
+                    $exceptionMessage = preg_replace('/^(Exception.*)$/m', "\033[01;31m$1\033[0m", $exceptionMessage);
+                    $exceptionMessage = preg_replace('/(Failed.*)$/m', "\033[01;31m %1\$s$1\033[0m", $exceptionMessage);
+                    $exceptionMessage = preg_replace("/(\-+.*)$/m", "\033[01;32m$1\033[0m", $exceptionMessage);
+                    $exceptionMessage = preg_replace("/(\++.*)$/m", "\033[01;31m$1\033[0m", $exceptionMessage);
+                }
+
+                $exceptionMessage = sprintf($exceptionMessage, $marker);
             }
+
             $exceptionMessage = '  ' . $exceptionMessage;
-            $exceptionMessage = sprintf($exceptionMessage, $marker);
 
             return $exceptionMessage;
         }


### PR DESCRIPTION
Fixes a potential fatal error from sprintf not getting enough arguments when formatting exception message in ResultPrinter71::formatExceptionMsg.
This occurred when the failing assertions had custom messages.

Additionally the fix prevents the same from occurring if an exception message contains %'s.

Other than that thank you for making our test output bearable to look at, as well as more informative.


Example output from it happening on circleci:

> Warning: sprintf(): Too few arguments in /home/circleci/project/vendor/codedungeon/phpunit-result-printer/src/ResultPrinter71.php on line 77

> Call Stack:
    0.0001     417616   1. {main}() /home/circleci/project/vendor/phpunit/phpunit/phpunit:0
    0.0463    3507608   2. PHPUnit\TextUI\Command::main() /home/circleci/project/vendor/phpunit/phpunit/phpunit:61
    0.0463    3507720   3. PHPUnit\TextUI\Command->run() /home/circleci/project/vendor/phpunit/phpunit/src/TextUI/Command.php:162
    0.3840   29197288   4. PHPUnit\TextUI\TestRunner->doRun() /home/circleci/project/vendor/phpunit/phpunit/src/TextUI/Command.php:206
 1106.6737   35645352   5. Codedungeon\PHPUnitPrettyResultPrinter\Printer->printResult() /home/circleci/project/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:633
 1106.6738   35645328   6. Codedungeon\PHPUnitPrettyResultPrinter\Printer->printFailures() /home/circleci/project/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:186
 1106.6738   35645328   7. Codedungeon\PHPUnitPrettyResultPrinter\Printer->printDefects() /home/circleci/project/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:385
 1106.6738   35646744   8. Codedungeon\PHPUnitPrettyResultPrinter\Printer->printDefect() /home/circleci/project/vendor/codedungeon/phpunit-result-printer/src/ResultPrinter71.php:126
 1106.6738   35646744   9. Codedungeon\PHPUnitPrettyResultPrinter\Printer->printDefectTrace() /home/circleci/project/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:354
 1106.6738   35646904  10. Codedungeon\PHPUnitPrettyResultPrinter\Printer->formatExceptionMsg() /home/circleci/project/vendor/codedungeon/phpunit-result-printer/src/ResultPrinter71.php:84
 1106.6740   35646936  11. sprintf() /home/circleci/project/vendor/codedungeon/phpunit-result-printer/src/ResultPrinter71.php:77