### PR TITLE
Supports a new option to show entire classname

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following options are available (along with their default values):
 | `cd-printer-hide-namespace`| true |Hide test class namespaces (will only show print class name)
 | `cd-printer-anybar`| true |Enable AnyBar (if anybar is not installed, settings will be ignored)
 | `cd-printer-anybar-port`| 1738 |Define AnyBar port number
+| `cd-printer-dont-format-classname`| false |Show entire classname or not
 
 #### Markers ###
 You can customize the markers which are used for `success`, `fail`, `error`, `skipped`, `incomplete` by modifying the `phpunit-printer.yml` file.

--- a/src/PrinterTrait.php
+++ b/src/PrinterTrait.php
@@ -2,8 +2,8 @@
 
 namespace Codedungeon\PHPUnitPrettyResultPrinter;
 
-use Noodlehaus\Config;
 use Codedungeon\PHPCliColors\Color;
+use Noodlehaus\Config;
 use Noodlehaus\Exception\EmptyDirectoryException;
 
 /**
@@ -55,6 +55,10 @@ trait PrinterTrait
      * @var mixed|null
      */
     private $showConfig;
+    /**
+     * @var bool
+     */
+    private $dontFormatClassName;
 
     /**
      * @var
@@ -262,12 +266,13 @@ trait PrinterTrait
 
         $this->printerOptions = array_merge($this->defaultConfigOptions, $this->printerOptions);
 
-        $this->hideClassName = $this->getConfigOption('cd-printer-hide-class');
-        $this->simpleOutput  = $this->getConfigOption('cd-printer-simple-output');
-        $this->showConfig    = $this->getConfigOption('cd-printer-show-config');
-        $this->hideNamespace = $this->getConfigOption('cd-printer-hide-namespace');
-        $this->anyBarEnabled = $this->getConfigOption('cd-printer-anybar');
-        $this->anyBarPort    = $this->getConfigOption('cd-printer-anybar-port');
+        $this->hideClassName          = $this->getConfigOption('cd-printer-hide-class');
+        $this->simpleOutput           = $this->getConfigOption('cd-printer-simple-output');
+        $this->showConfig             = $this->getConfigOption('cd-printer-show-config');
+        $this->hideNamespace          = $this->getConfigOption('cd-printer-hide-namespace');
+        $this->anyBarEnabled          = $this->getConfigOption('cd-printer-anybar');
+        $this->anyBarPort             = $this->getConfigOption('cd-printer-anybar-port');
+        $this->dontFormatClassName    = $this->getConfigOption('cd-printer-dont-format-classname');
 
         $this->markers = [
             'pass'         => $this->getConfigMarker('cd-pass'),
@@ -364,8 +369,13 @@ trait PrinterTrait
         $prefix   = ' ==> ';
         $ellipsis = '...';
         $suffix   = '   ';
+
         if ($this->hideNamespace && strrpos($className, '\\')) {
             $className = substr($className, strrpos($className, '\\') + 1);
+        }
+
+        if ($this->dontFormatClassName) {
+            return $prefix . $className . $suffix;
         }
         $formattedClassName = $prefix . $className . $suffix;
 

--- a/src/PrinterTrait.php
+++ b/src/PrinterTrait.php
@@ -2,8 +2,8 @@
 
 namespace Codedungeon\PHPUnitPrettyResultPrinter;
 
-use Codedungeon\PHPCliColors\Color;
 use Noodlehaus\Config;
+use Codedungeon\PHPCliColors\Color;
 use Noodlehaus\Exception\EmptyDirectoryException;
 
 /**
@@ -266,13 +266,13 @@ trait PrinterTrait
 
         $this->printerOptions = array_merge($this->defaultConfigOptions, $this->printerOptions);
 
-        $this->hideClassName          = $this->getConfigOption('cd-printer-hide-class');
-        $this->simpleOutput           = $this->getConfigOption('cd-printer-simple-output');
-        $this->showConfig             = $this->getConfigOption('cd-printer-show-config');
-        $this->hideNamespace          = $this->getConfigOption('cd-printer-hide-namespace');
-        $this->anyBarEnabled          = $this->getConfigOption('cd-printer-anybar');
-        $this->anyBarPort             = $this->getConfigOption('cd-printer-anybar-port');
-        $this->dontFormatClassName    = $this->getConfigOption('cd-printer-dont-format-classname');
+        $this->hideClassName       = $this->getConfigOption('cd-printer-hide-class');
+        $this->simpleOutput        = $this->getConfigOption('cd-printer-simple-output');
+        $this->showConfig          = $this->getConfigOption('cd-printer-show-config');
+        $this->hideNamespace       = $this->getConfigOption('cd-printer-hide-namespace');
+        $this->anyBarEnabled       = $this->getConfigOption('cd-printer-anybar');
+        $this->anyBarPort          = $this->getConfigOption('cd-printer-anybar-port');
+        $this->dontFormatClassName = $this->getConfigOption('cd-printer-dont-format-classname');
 
         $this->markers = [
             'pass'         => $this->getConfigMarker('cd-pass'),

--- a/src/PrinterTrait8.php
+++ b/src/PrinterTrait8.php
@@ -2,8 +2,8 @@
 
 namespace Codedungeon\PHPUnitPrettyResultPrinter;
 
-use Codedungeon\PHPCliColors\Color;
 use Noodlehaus\Config;
+use Codedungeon\PHPCliColors\Color;
 use Noodlehaus\Exception\EmptyDirectoryException;
 
 /**
@@ -266,13 +266,13 @@ trait PrinterTrait8
 
         $this->printerOptions = array_merge($this->defaultConfigOptions, $this->printerOptions);
 
-        $this->hideClassName          = $this->getConfigOption('cd-printer-hide-class');
-        $this->simpleOutput           = $this->getConfigOption('cd-printer-simple-output');
-        $this->showConfig             = $this->getConfigOption('cd-printer-show-config');
-        $this->hideNamespace          = $this->getConfigOption('cd-printer-hide-namespace');
-        $this->anyBarEnabled          = $this->getConfigOption('cd-printer-anybar');
-        $this->anyBarPort             = $this->getConfigOption('cd-printer-anybar-port');
-        $this->dontFormatClassName    = $this->getConfigOption('cd-printer-dont-format-classname');
+        $this->hideClassName       = $this->getConfigOption('cd-printer-hide-class');
+        $this->simpleOutput        = $this->getConfigOption('cd-printer-simple-output');
+        $this->showConfig          = $this->getConfigOption('cd-printer-show-config');
+        $this->hideNamespace       = $this->getConfigOption('cd-printer-hide-namespace');
+        $this->anyBarEnabled       = $this->getConfigOption('cd-printer-anybar');
+        $this->anyBarPort          = $this->getConfigOption('cd-printer-anybar-port');
+        $this->dontFormatClassName = $this->getConfigOption('cd-printer-dont-format-classname');
 
         $this->markers = [
             'pass'         => $this->getConfigMarker('cd-pass'),

--- a/src/PrinterTrait8.php
+++ b/src/PrinterTrait8.php
@@ -2,8 +2,8 @@
 
 namespace Codedungeon\PHPUnitPrettyResultPrinter;
 
-use Noodlehaus\Config;
 use Codedungeon\PHPCliColors\Color;
+use Noodlehaus\Config;
 use Noodlehaus\Exception\EmptyDirectoryException;
 
 /**
@@ -55,6 +55,10 @@ trait PrinterTrait8
      * @var mixed|null
      */
     private $showConfig;
+    /**
+     * @var bool
+     */
+    private $dontFormatClassName;
 
     /**
      * @var
@@ -262,12 +266,13 @@ trait PrinterTrait8
 
         $this->printerOptions = array_merge($this->defaultConfigOptions, $this->printerOptions);
 
-        $this->hideClassName = $this->getConfigOption('cd-printer-hide-class');
-        $this->simpleOutput  = $this->getConfigOption('cd-printer-simple-output');
-        $this->showConfig    = $this->getConfigOption('cd-printer-show-config');
-        $this->hideNamespace = $this->getConfigOption('cd-printer-hide-namespace');
-        $this->anyBarEnabled = $this->getConfigOption('cd-printer-anybar');
-        $this->anyBarPort    = $this->getConfigOption('cd-printer-anybar-port');
+        $this->hideClassName          = $this->getConfigOption('cd-printer-hide-class');
+        $this->simpleOutput           = $this->getConfigOption('cd-printer-simple-output');
+        $this->showConfig             = $this->getConfigOption('cd-printer-show-config');
+        $this->hideNamespace          = $this->getConfigOption('cd-printer-hide-namespace');
+        $this->anyBarEnabled          = $this->getConfigOption('cd-printer-anybar');
+        $this->anyBarPort             = $this->getConfigOption('cd-printer-anybar-port');
+        $this->dontFormatClassName    = $this->getConfigOption('cd-printer-dont-format-classname');
 
         $this->markers = [
             'pass'         => $this->getConfigMarker('cd-pass'),
@@ -364,9 +369,15 @@ trait PrinterTrait8
         $prefix   = ' ==> ';
         $ellipsis = '...';
         $suffix   = '   ';
+
         if ($this->hideNamespace && strrpos($className, '\\')) {
             $className = substr($className, strrpos($className, '\\') + 1);
         }
+
+        if ($this->dontFormatClassName) {
+            return $prefix . $className . $suffix;
+        }
+
         $formattedClassName = $prefix . $className . $suffix;
 
         if (\strlen($formattedClassName) <= $this->maxClassNameLength) {

--- a/src/phpunit-printer.yml
+++ b/src/phpunit-printer.yml
@@ -5,7 +5,7 @@ options:
   cd-printer-hide-namespace: true
   cd-printer-anybar: false
   cd-printer-anybar-port: 1738
-  cd-printer-dont-format-classname: true
+  cd-printer-dont-format-classname: false
 markers:
   cd-pass: "✔ "
   cd-fail: "✖ "

--- a/src/phpunit-printer.yml
+++ b/src/phpunit-printer.yml
@@ -5,6 +5,7 @@ options:
   cd-printer-hide-namespace: true
   cd-printer-anybar: false
   cd-printer-anybar-port: 1738
+  cd-printer-dont-format-classname: true
 markers:
   cd-pass: "✔ "
   cd-fail: "✖ "


### PR DESCRIPTION
# Description
This PR add a new option `cd-printer-dont-format-classname`
