### PR TITLE
Add configuration showLegend to control if a "marker legend" is shown

### DIFF
--- a/phpunit-printer.yml
+++ b/phpunit-printer.yml
@@ -6,6 +6,7 @@ options:
   cd-printer-anybar: true
   cd-printer-anybar-port: 1738
   cd-printer-dont-format-classname: false
+  cd-printer-show-legend: true
 markers:
   cd-pass: "✔ "
   cd-fail: "✖ "

--- a/src/PrinterTrait.php
+++ b/src/PrinterTrait.php
@@ -80,6 +80,16 @@ trait PrinterTrait
      */
     private $dontFormatClassName;
 
+    /**
+     * @var bool
+     */
+    private $showLegend;
+
+    /**
+     * @var int
+     */
+    protected $columnsInLegend;
+
     private $markerColors = [
         'pass' => 'fg-green',
         'skipped' => 'fg-yellow,bold',
@@ -108,6 +118,7 @@ trait PrinterTrait
 
         $this->maxNumberOfColumns = $this->getWidth() - 5;
         $this->maxClassNameLength = min((int) ($this->maxNumberOfColumns / 2), $this->maxClassNameLength);
+        $this->columnsInLegend = min(ceil($this->maxClassNameLength / 18), 3); // 3 columns max;
 
         if ($this->hideNamespace) {
             $this->maxClassNameLength = 32;
@@ -205,6 +216,20 @@ trait PrinterTrait
                 echo PHP_EOL . PHP_EOL;
             }
 
+            if ($this->showLegend) {
+                $col = 1;
+
+                echo ($use_color !== 'never' ? $this->colorsTool->normal() : '').'==> Legend: '.PHP_EOL.'|';
+
+                foreach ($this->markers as $key => $marker) {
+                    echo parent::formatWithColor($this->resolveColor($key), ' '.str_pad("${marker}", 3, " "));
+                    echo $this->colorsTool->reset().str_pad(" - $key", 15, " ");
+                    echo ($col++ % $this->columnsInLegend == 0 ? '|'.PHP_EOL.($col < count($this->markers) ? '|' : '') : '|');
+                }
+                echo $use_color !== 'never' ? $this->colorsTool->reset() : '';
+
+                echo PHP_EOL;
+            }
             self::$init = true;
         }
     }
@@ -295,6 +320,7 @@ trait PrinterTrait
         $this->anyBarEnabled       = $this->getConfigOption('cd-printer-anybar');
         $this->anyBarPort          = $this->getConfigOption('cd-printer-anybar-port');
         $this->dontFormatClassName = $this->getConfigOption('cd-printer-dont-format-classname');
+        $this->showLegend          = $this->getConfigOption('cd-printer-show-legend');
 
         if (!strpos(php_uname(), 'Darwin')) {
             $this->anyBarEnabled = false;

--- a/src/PrinterTrait.php
+++ b/src/PrinterTrait.php
@@ -80,6 +80,15 @@ trait PrinterTrait
      */
     private $dontFormatClassName;
 
+    private $markerColors = [
+        'pass' => 'fg-green',
+        'skipped' => 'fg-yellow,bold',
+        'incomplete' => 'fg-blue,bold',
+        'fail' => 'fg-red,bold',
+        'error' => 'fg-red,bold',
+        'risky' => 'fg-magenta,bold'
+    ];
+
     /**
      * {@inheritdoc}
      */
@@ -419,6 +428,17 @@ trait PrinterTrait
     }
 
     /**
+     * @param string $text
+     *
+     * @return string
+     */
+    protected function resolveColor($text)
+    {
+        return empty($text) ? $this->colorsTool->normal() : $this->markerColors[$text];
+    }
+
+
+    /**
      * @param string $color
      * @param string $buffer Result of the Test Case => . F S I R
      */
@@ -432,32 +452,32 @@ trait PrinterTrait
         }
         switch (strtoupper($buffer)) {
             case '.':
-                $color  = 'fg-green';
+                $color  = $this->resolveColor('pass');
                 $buffer = $this->simpleOutput ? '.' : $this->markers['pass']; // mb_convert_encoding("\x27\x13", 'UTF-8', 'UTF-16BE');
                 $buffer .= (!$this->debug) ? '' : ' Passed';
                 break;
             case 'S':
-                $color  = 'fg-yellow,bold';
+                $color  = $this->resolveColor('skipped');
                 $buffer = $this->simpleOutput ? 'S' : $this->markers['skipped']; // mb_convert_encoding("\x27\xA6", 'UTF-8', 'UTF-16BE');
                 $buffer .= !$this->debug ? '' : ' Skipped';
                 break;
             case 'I':
-                $color  = 'fg-blue,bold';
+                $color  = $this->resolveColor('incomplete');
                 $buffer = $this->simpleOutput ? 'I' : $this->markers['incomplete']; // 'ℹ';
                 $buffer .= !$this->debug ? '' : ' Incomplete';
                 break;
             case 'F':
-                $color  = 'fg-red,bold';
+                $color  = $this->resolveColor('fail');
                 $buffer = $this->simpleOutput ? 'F' : $this->markers['fail']; // mb_convert_encoding("\x27\x16", 'UTF-8', 'UTF-16BE');
                 $buffer .= (!$this->debug) ? '' : ' Fail';
                 break;
             case 'E':
-                $color  = 'fg-red,bold';
+                $color  = $this->resolveColor('error');
                 $buffer = $this->simpleOutput ? 'E' : $this->markers['error']; // '⚈';
                 $buffer .= !$this->debug ? '' : ' Error';
                 break;
             case 'R':
-                $color  = 'fg-magenta,bold';
+                $color  = $this->resolveColor('risky');
                 $buffer = $this->simpleOutput ? 'R' : $this->markers['risky']; // '⚙';
                 $buffer .= !$this->debug ? '' : ' Risky';
                 break;

--- a/src/PrinterTrait.php
+++ b/src/PrinterTrait.php
@@ -91,12 +91,12 @@ trait PrinterTrait
     protected $columnsInLegend;
 
     private $markerColors = [
-        'pass' => 'fg-green',
-        'skipped' => 'fg-yellow,bold',
+        'pass'       => 'fg-green',
+        'skipped'    => 'fg-yellow,bold',
         'incomplete' => 'fg-blue,bold',
-        'fail' => 'fg-red,bold',
-        'error' => 'fg-red,bold',
-        'risky' => 'fg-magenta,bold'
+        'fail'       => 'fg-red,bold',
+        'error'      => 'fg-red,bold',
+        'risky'      => 'fg-magenta,bold',
     ];
 
     /**
@@ -118,7 +118,7 @@ trait PrinterTrait
 
         $this->maxNumberOfColumns = $this->getWidth() - 5;
         $this->maxClassNameLength = min((int) ($this->maxNumberOfColumns / 2), $this->maxClassNameLength);
-        $this->columnsInLegend = min(ceil($this->maxClassNameLength / 18), 3); // 3 columns max;
+        $this->columnsInLegend    = min(ceil($this->maxClassNameLength / 18), 3); // 3 columns max;
 
         if ($this->hideNamespace) {
             $this->maxClassNameLength = 32;
@@ -219,12 +219,12 @@ trait PrinterTrait
             if ($this->showLegend) {
                 $col = 1;
 
-                echo ($use_color !== 'never' ? $this->colorsTool->normal() : '').'==> Legend: '.PHP_EOL.'|';
+                echo($use_color !== 'never' ? $this->colorsTool->normal() : '').'==> Legend: '.PHP_EOL.'|';
 
                 foreach ($this->markers as $key => $marker) {
-                    echo parent::formatWithColor($this->resolveColor($key), ' '.str_pad("${marker}", 3, " "));
-                    echo $this->colorsTool->reset().str_pad(" - $key", 15, " ");
-                    echo ($col++ % $this->columnsInLegend == 0 ? '|'.PHP_EOL.($col < count($this->markers) ? '|' : '') : '|');
+                    echo parent::formatWithColor($this->resolveColor($key), ' '.str_pad("${marker}", 3, ' '));
+                    echo $this->colorsTool->reset().str_pad(" - $key", 15, ' ');
+                    echo $col++ % $this->columnsInLegend == 0 ? '|'.PHP_EOL.($col < count($this->markers) ? '|' : '') : '|';
                 }
                 echo $use_color !== 'never' ? $this->colorsTool->reset() : '';
 
@@ -462,7 +462,6 @@ trait PrinterTrait
     {
         return empty($text) ? $this->colorsTool->normal() : $this->markerColors[$text];
     }
-
 
     /**
      * @param string $color

--- a/src/phpunit-printer.yml
+++ b/src/phpunit-printer.yml
@@ -6,6 +6,7 @@ options:
   cd-printer-anybar: false
   cd-printer-anybar-port: 1738
   cd-printer-dont-format-classname: false
+  cd-printer-show-legend: true
 markers:
   cd-pass: "✔ "
   cd-fail: "✖ "


### PR DESCRIPTION
Remind yourself what the symbols/markers you've chosen actually represent!

```
  cd-printer-show-legend: true
```

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Add configuration `showLegend` to remind yourself of what the marks per test actually mean.

<img width="604" alt="show-legend-default" src="https://user-images.githubusercontent.com/3782881/175749962-92bbc802-1350-4f92-99d5-9d16ac7204f3.png">

<img width="595" alt="show-legend-custom-1" src="https://user-images.githubusercontent.com/3782881/175749972-ef1f93c6-b9b2-45fe-b982-0dbb1bebcccd.png">


**Which issue (if any) does this pull request address?**
None

**Is there anything you'd like reviewers to focus on?**
