### PR TITLE
chore: Replace string interpolation and dynamic property php8.2 deprecation

### DIFF
--- a/src/PrinterTrait8.php
+++ b/src/PrinterTrait8.php
@@ -22,11 +22,11 @@ trait PrinterTrait8
     /**
      * @var int
      */
-    private $anyBarPort;
+    protected $anyBarPort;
     /**
      * @var bool
      */
-    private $anyBarEnabled;
+    protected $anyBarEnabled;
     /**
      * @var Color
      */

--- a/src/PrinterTrait8.php
+++ b/src/PrinterTrait8.php
@@ -31,7 +31,6 @@ trait PrinterTrait8
      * @var Color
      */
     private $colorsTool;
-
     /**
      * @var array|null
      */

--- a/src/PrinterTrait8.php
+++ b/src/PrinterTrait8.php
@@ -20,6 +20,23 @@ trait PrinterTrait8
      */
     public $className = '';
     /**
+     * @var int
+     */
+    private $anyBarPort;
+    /**
+     * @var bool
+     */
+    private $anyBarEnabled;
+    /**
+     * @var Color
+     */
+    private $colorsTool;
+
+    /**
+     * @var array|null
+     */
+    private $defaultConfigOptions;
+    /**
      * @var string
      */
     private $lastClassName = '';
@@ -171,10 +188,10 @@ trait PrinterTrait8
             $name    = $this->packageName();
             echo PHP_EOL;
             if ($use_color !== 'never') {
-                echo $this->colorsTool->green() . "${name} ${version} by Codedungeon and contributors." . PHP_EOL;
+                echo $this->colorsTool->green() . "{$name} {$version} by Codedungeon and contributors." . PHP_EOL;
                 echo $this->colorsTool->reset();
             } else {
-                echo "${name} ${version} by Codedungeon and contributors." . PHP_EOL;
+                echo "{$name} {$version} by Codedungeon and contributors." . PHP_EOL;
             }
 
             if ($this->showConfig) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[X] Other, please explain:

Chore to remove the PHP8.2 Deprecation Warnings.

![Screenshot 2023-11-02 at 11 02 09](https://github.com/mikeerickson/phpunit-pretty-result-printer/assets/37993394/ea197bcd-839b-4562-a569-536c3f3a1727)

![Screenshot 2023-11-02 at 11 02 27](https://github.com/mikeerickson/phpunit-pretty-result-printer/assets/37993394/de4eb20a-fe4c-45de-a1cf-038f8c8e610e)

**What changes did you make? (Give an overview)**

- Replaced `${variable}` `{$variable}`-
- Explicitly declared the private variables that were being dynamically declared/

**Which issue (if any) does this pull request address?**

No Opened Issues

**Is there anything you'd like reviewers to focus on?**

Not Specifically